### PR TITLE
fix: responsive styles

### DIFF
--- a/src/app/[id]/proofs/[proofId]/page.tsx
+++ b/src/app/[id]/proofs/[proofId]/page.tsx
@@ -133,9 +133,9 @@ const ProofInfo = ({ params }: { params: Promise<{ id: string; proofId: string }
 
   return (
     (<div className="mx-4 my-16 flex flex-col gap-6 rounded-3xl border border-grey-500 bg-white p-6 shadow-[2px_4px_2px_0px_rgba(0,0,0,0.02),_2px_3px_4.5px_0px_rgba(0,0,0,0.07)]">
-      <div className="flex flex-row items-center justify-between">
+      <div className="flex flex-row items-center justify-between flex-wrap gap-2">
         <h4 className="text-xl font-bold text-grey-900">Proof Details</h4>
-        <div className="flex flex-row gap-2">
+        <div className="flex flex-row flex-wrap gap-2">
           <Button
             loading={isVerifyingProofLoading}
             variant="secondary"
@@ -215,7 +215,7 @@ const ProofInfo = ({ params }: { params: Promise<{ id: string; proofId: string }
           <Link
             target="_blank"
             href={`https://sepolia.basescan.org/address/${blueprint?.props.verifierContract?.address}`}
-            className="text-base font-medium text-grey-800 underline"
+            className="text-base font-medium text-grey-800 underline break-words"
           >
             {blueprint?.props.verifierContract?.address || '-'}
           </Link>

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -23,7 +23,7 @@ const Navbar = () => {
             maxWidth: "100%",
             height: "auto"
           }} />
-        <span className="text-xl font-semibold dark:text-white">registry</span>
+        <span className="text-xl font-semibold text-[#1C1C1C] dark:text-white">registry</span>
       </Link>
       <div className="flex items-center gap-4">
         {token && !pathname.includes('/create') ? (

--- a/src/app/template.tsx
+++ b/src/app/template.tsx
@@ -36,10 +36,7 @@ export default function Template({ children }: { children: React.ReactNode }) {
           width={4000}
           height={200}
           priority
-          style={{
-            maxWidth: "100%",
-            height: "auto"
-          }} />
+        />
       </div>
     )}
     <div className="mx-auto w-full flex-grow md:w-[768px] px-4 md:px-0">{children}</div>


### PR DESCRIPTION
Fixes:
- Banner on large displays
<img width="3002" alt="image" src="https://github.com/user-attachments/assets/137f366a-7079-42a9-b1e7-7c49ecc99543" />
<img width="3006" alt="image" src="https://github.com/user-attachments/assets/cae25b1e-f0ac-4eae-a15a-372eaa5e3b86" />


- Overlap on laptop
<img width="1800" alt="image" src="https://github.com/user-attachments/assets/9ee12a0a-2532-404c-9d49-58f1b7ed8efc" />
<img width="1798" alt="image" src="https://github.com/user-attachments/assets/9d6d85b5-0433-43a7-9aed-cac869c0adec" />


- Proof details overlaps and red text as logo. I couldn't find a reason why the red text shows, on incognito or other browsers looks correct
  
<img width="390" alt="image" src="https://github.com/user-attachments/assets/7171c8ba-f5b4-4771-a2c3-6c9d7a1e1b62" />
<img width="388" alt="image" src="https://github.com/user-attachments/assets/38792263-543c-441b-a4d5-105a6b64b5b0" />



