### PR TITLE
fixed extraction of sender domain to be everything from @

### DIFF
--- a/src/app/utils.tsx
+++ b/src/app/utils.tsx
@@ -145,10 +145,8 @@ async function extractEMLDetails(emlContent: string) {
 
   const senderDomain =
     headers['From']
-      ?.match(/@([^\s>]+)/)?.[1]
-      ?.split('.')
-      .slice(-2)
-      .join('.') || null;
+      ?.match(/@([^\s>]+)/)?.[1] || null;
+
   const selector = getDKIMSelector(emlContent);
   const emailQuery = `from:${senderDomain}`;
   const parsedEmail = await parseEmail(emlContent);


### PR DESCRIPTION
Fixes parsing of sender domain from eml to be everything after `@` char instead of only the last two parts after this