### PR TITLE
fix: set default isPublic of bp props true

### DIFF
--- a/src/app/create/[id]/store.ts
+++ b/src/app/create/[id]/store.ts
@@ -44,7 +44,7 @@ const initialState: BlueprintProps = {
   senderDomain: '',
   enableHeaderMasking: false,
   enableBodyMasking: false,
-  isPublic: false,
+  isPublic: true,
   verifierContract: {
     chain: 84532,
     address: '',


### PR DESCRIPTION
isPublic should be true by default, otherwise all blueprints are not findable by default in the registry.