### PR TITLE
:fix: Update the order of useEffects being called during github auth

### DIFF
--- a/src/app/create/[id]/page.tsx
+++ b/src/app/create/[id]/page.tsx
@@ -295,6 +295,12 @@ const CreateBlueprint = ({ params }: { params: Promise<{ id: string }> }) => {
     };
   }, [JSON.stringify(store.senderDomain), dkimSelector, step]);
 
+  useEffect(() => {
+    if (step === '2') {
+      genrateHighlightRegexContent();
+    }
+  }, [JSON.stringify(store.decomposedRegexes), savedEmls[id]]);
+
   const isNextButtonDisabled = () => {
     if (!savedEmls[id] || isFileInvalid) {
       return true;
@@ -356,12 +362,6 @@ const CreateBlueprint = ({ params }: { params: Promise<{ id: string }> }) => {
       </div>
     );
   }
-
-  useEffect(() => {
-    if (step === '2') {
-      genrateHighlightRegexContent();
-    }
-  }, [JSON.stringify(store.decomposedRegexes), savedEmls[id]]);
 
   const genrateHighlightRegexContent = async () => {
     if (!savedEmls[id]) {


### PR DESCRIPTION
Due to incorrect order of useEffects, a race condition is occuring in the create blueprint flow randomly. During this, the github token is being fetched but some useEffect that requires it, runs before it and crashes the application