### PR TITLE
:fix: prevent form prefilling when creating new Blueprint during acti…

### DIFF
--- a/src/app/create/[id]/store.ts
+++ b/src/app/create/[id]/store.ts
@@ -25,6 +25,8 @@ interface ExtendedBlueprintProps extends BlueprintProps {
 type CreateBlueprintState = ExtendedBlueprintProps & {
   blueprint: Blueprint | null;
   validationErrors: ValidationErrors;
+  hasHydrated: boolean;
+  setHasHydrated: (value: boolean) => void;
   setField: (field: keyof ExtendedBlueprintProps, value: any) => void;
   validateField: (field: keyof BlueprintProps) => void;
   validateAll: () => boolean;
@@ -76,6 +78,8 @@ export const useCreateBlueprintStore = create<CreateBlueprintState>()(
       blueprint: null,
       validationErrors: {},
       file: null,
+      hasHydrated: false,
+      setHasHydrated: (value: boolean) => set({ hasHydrated: value }),
 
       setField: (field: keyof ExtendedBlueprintProps, value: any) => {
         set({ [field]: value });
@@ -335,8 +339,12 @@ export const useCreateBlueprintStore = create<CreateBlueprintState>()(
       name: 'create-blueprint',
       // Exclude 'file' from persistence as File objects cannot be serialized
       partialize: (state) => {
-        const { file, blueprint, ...rest } = state;
+        const { file, blueprint, hasHydrated, setHasHydrated, ...rest } = state;
         return rest;
+      },
+      onRehydrateStorage: () => (state) => {
+        // This is called after the store has been rehydrated from storage
+        state?.setHasHydrated(true);
       },
       storage: {
         getItem: async (name) => {

--- a/src/app/create/[id]/store.ts
+++ b/src/app/create/[id]/store.ts
@@ -344,7 +344,11 @@ export const useCreateBlueprintStore = create<CreateBlueprintState>()(
       },
       onRehydrateStorage: () => (state) => {
         // This is called after the store has been rehydrated from storage
-        state?.setHasHydrated(true);
+        if (state) {
+          state.setHasHydrated(true);
+        } else {
+          useCreateBlueprintStore.setState({ hasHydrated: true });
+        }
       },
       storage: {
         getItem: async (name) => {


### PR DESCRIPTION
…ve generation

When navigating to create a new Blueprint while another generation was in progress, the form would be prefilled with data from the previous Blueprint. This was caused by a race condition where the zustand store's reset() was called before the persist middleware finished rehydrating from IndexedDB, causing the hydrated state to overwrite the reset.

Added hydration tracking to the create blueprint store:
- Added hasHydrated state and onRehydrateStorage callback
- Updated useEffect to wait for hydration before calling reset()
- Added loader during hydration to prevent flash of stale content

Fixes #273

## Summary

<!-- Brief description of what this PR does -->

## Type of Change

- [x] Bug fix (hotfix)
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Target Branch

- [x] `dev` - New feature or non-urgent fix
- [ ] `staging` - Ready for QA validation
- [ ] `main` - Hotfix for production issue

## Changes Made

<!-- List the key changes in this PR -->

-

## Breaking Changes

<!-- List any breaking changes, or write "None" -->

## Testing

<!-- How did you test these changes? -->

- [x] Tested locally
- [ ] Added/updated tests
- [x] Verified in development environment

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex code sections
- [x] Documentation updated if needed
- [x] No new warnings generated

## Screenshots/Recordings

<!-- Add screenshots/recordings for UI changes -->

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Additional Notes

<!-- Add any additional notes, or remove this section if not needed -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed race condition in create blueprint workflow that could cause state inconsistencies during page load by ensuring initialization operations respect component hydration timing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->