### PR TITLE
feat: disable Circom for client-side ZK framework

### DIFF
--- a/src/app/[id]/AddInputs.tsx
+++ b/src/app/[id]/AddInputs.tsx
@@ -142,7 +142,7 @@ const AddInputs = () => {
                   While it may take a bit more time, your email remains securely on your system.
                 </>
               ) : (
-                'Local proving only works for blueprints compiled with Circom'
+                'Local proving is not available for this blueprint'
               )}
             </p>
           </div>

--- a/src/app/[id]/SelectEmails.tsx
+++ b/src/app/[id]/SelectEmails.tsx
@@ -499,16 +499,16 @@ const SelectEmails = ({ id }: { id: string }) => {
                   </div>
                 </div>
                 <p className="text-base text-grey-700">
-                  {blueprint?.props.serverZkFramework &&
+                  {blueprint?.props.clientZkFramework &&
                   // @ts-ignore ZkFramework can be None
-                  blueprint?.props.serverZkFramework !== ZkFramework.None ? (
+                  blueprint?.props.clientZkFramework !== ZkFramework.None ? (
                     <>
                       This method prioritizes your privacy by generating proofs directly on your
                       device. While it may take a bit more time, your email remains securely on your
                       system.
                     </>
                   ) : (
-                    'Local proving only works for blueprints compiled with Circom'
+                    'Local proving is not available for this blueprint'
                   )}
                 </p>
               </div>

--- a/src/app/create/[id]/createBlueprintSteps/EmailDetails.tsx
+++ b/src/app/create/[id]/createBlueprintSteps/EmailDetails.tsx
@@ -255,16 +255,11 @@ const EmailDetails = ({
           console.log('setting clientZkFramework to ', value);
           setField('clientZkFramework', value);
         }}
-        options={
-          // TODO: remove these comments once circom client side works
-          // process.env.NEXT_PUBLIC_DEPLOYMENT_ENV === 'staging'
-          //   ?
-          [
-            // { label: 'Circom', value: ZkFramework.Circom },
-            { label: 'Noir', value: ZkFramework.Noir },
-          ]
-          // : [{ label: 'Circom', value: ZkFramework.Circom }]
-        }
+        options={[
+          // TODO: Re-enable Circom option once client-side Circom proving is fixed
+          // { label: 'Circom', value: ZkFramework.Circom },
+          { label: 'Noir', value: ZkFramework.Noir },
+        ]}
       />
       {isNoirIncompatible ? (
         <div className="flex w-full flex-row gap-7 rounded-2xl border border-[#FFF085] bg-[#FEFCE8] px-4 py-6">

--- a/src/app/create/[id]/store.ts
+++ b/src/app/create/[id]/store.ts
@@ -63,7 +63,7 @@ const initialState: ExtendedBlueprintProps = {
   },
   externalInputs: [],
   decomposedRegexes: [],
-  clientZkFramework: ZkFramework.Circom,
+  clientZkFramework: ZkFramework.Noir,
   serverZkFramework: ZkFramework.Circom,
   internalVersion: '0002_max_length_per_regex_part',
 };
@@ -200,14 +200,8 @@ export const useCreateBlueprintStore = create<CreateBlueprintState>()(
           if (!state.id || state.id === 'new') {
             console.log('creating a new blueprint');
             const blueprint = sdk.createBlueprint(data);
-            if (emlStr) {
-              await blueprint.assignPreferredZkFramework(emlStr);
-            } else {
-              data.clientZkFramework = ZkFramework.Noir;
-              data.serverZkFramework = ZkFramework.Sp1;
-            }
-            console.log('Assigned clientZkFramework: ', blueprint.props.clientZkFramework);
-            console.log('Assigned serverZkFramework: ', blueprint.props.serverZkFramework);
+            // Framework selection is user-driven via UI dropdowns
+            // Defaults are set in initialState (Noir for client, Circom for server)
             await blueprint.submitDraft();
             console.log('saved draft');
             set({ blueprint });
@@ -238,13 +232,6 @@ export const useCreateBlueprintStore = create<CreateBlueprintState>()(
           console.log('setting existing blueprint');
           const currentState = get();
           const blueprint = await sdk.getBlueprintById(id);
-
-          // Assign preferred ZK framework based on email content if available
-          const emlStore = useEmlStore.getState();
-          const savedEmls = await emlStore.getAllEmls();
-          if (savedEmls[id]) {
-            await blueprint.assignPreferredZkFramework(savedEmls[id]);
-          }
 
           // TODO: sdk should not return undefined fields - workaround so we have sane defaults
           for (const [key, value] of Object.entries(blueprint.props)) {


### PR DESCRIPTION
## Summary

Disable Circom as an option for client-side ZK framework, defaulting to Noir instead. Fixes the empty dropdown bug where the default value didn't match any available options.

## Type of Change

- [x] Bug fix (hotfix)
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Target Branch

- [ ] `dev` - New feature or non-urgent fix
- [ ] `staging` - Ready for QA validation
- [x] `main` - Hotfix for production issue

## Changes Made

- Default `clientZkFramework` changed from `Circom` to `Noir` in store initial state
- Removed `assignPreferredZkFramework()` SDK calls that could override user selections
- Cleaned up client framework dropdown options and TODO comments
- Fixed local proving check from `serverZkFramework` to `clientZkFramework`
- Updated fallback messages to be framework-agnostic ("Local proving is not available for this blueprint")

## Breaking Changes

None. Existing blueprints with `clientZkFramework: Circom` retain their stored value. Download code still supports Circom for legacy blueprints.

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] Verified in development environment

Manual testing completed:
- New blueprint defaults to Noir in dropdown (not empty)
- Loading existing blueprint preserves saved framework values

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex code sections
- [x] Documentation updated if needed
- [x] No new warnings generated

## Screenshots/Recordings

<img width="775" height="806" alt="Screenshot 2026-01-16 at 18 56 45" src="https://github.com/user-attachments/assets/88ee4bb7-8834-493b-9734-eeeefe5185f4" />

## Related Issues

Fixes [REG-640](https://linear.app/zk-email/issue/REG-640)

## Additional Notes

- Server-side Circom support remains intact
- Circom client-side download code preserved for legacy blueprints and future re-enablement
- To re-enable Circom: uncomment the option in EmailDetails.tsx dropdown


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Local Proving guidance message updated for clarity.
  * Circom removed from Client ZK Framework options; Noir is now the only available choice.
  * Default Client ZK Framework changed to Noir.
  * Framework selection now requires manual configuration through the UI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->