### PR TITLE
docs: add Kusama grant milestone-3 delivery evidence (frontend)

### DIFF
--- a/docs/kusama-grant/README.md
+++ b/docs/kusama-grant/README.md
@@ -1,0 +1,11 @@
+# Kusama Grant Documentation Index
+
+This directory tracks delivery evidence for Kusama grant milestones related to the ZK-Email registry (frontend).
+
+## Milestones
+
+- Milestone 3 (this repository): [`./milestone-3/00_overview.md`](./milestone-3/00_overview.md)
+
+## Current Status Snapshot
+
+- Milestone 3: `Delivered`

--- a/docs/kusama-grant/milestone-3/00_overview.md
+++ b/docs/kusama-grant/milestone-3/00_overview.md
@@ -1,0 +1,19 @@
+# Milestone 3 - Frontend PolkaVM Support
+
+Primary Goal: Add PolkaVM/Paseo Testnet on-chain verification support to the ZK-Email registry UI, enabling users to select a target chain when creating blueprints and to verify Circom proofs on-chain against the deployed verifier contract.
+
+## Deliverables (this repository)
+
+| # | Name | Description | Status |
+| --- | --- | --- | --- |
+| 1 | Chain Selection UI | Chain selector dropdown in blueprint creation step 3 (Optional Details) allowing users to choose between Ethereum Sepolia and Paseo Testnet (Polkadot) as the deployment target. | `Delivered` |
+| 2 | On-Chain Verification UI | "Verify On-Chain" button on the proof list and proof detail pages, enabled only when a wallet is detected, a verifier contract address is set, and the proof is Circom-based. | `Delivered` |
+| 3 | Dynamic Block Explorer Links | Verifier contract address links that resolve to the correct explorer (Etherscan for Sepolia, Blockscout for Paseo) based on the blueprint's target chain. | `Delivered` |
+| 4 | ZK Framework Selection Fix | Removed hardcoded fallback that forced Noir/SP1 when no email was uploaded; user-selected frameworks are now respected. | `Delivered` |
+
+## Evidence Index
+
+- [`01_chain_selection_ui.md`](./01_chain_selection_ui.md)
+- [`02_on_chain_verification_ui.md`](./02_on_chain_verification_ui.md)
+- [`03_dynamic_explorer_links.md`](./03_dynamic_explorer_links.md)
+- [`04_zk_framework_fix.md`](./04_zk_framework_fix.md)

--- a/docs/kusama-grant/milestone-3/01_chain_selection_ui.md
+++ b/docs/kusama-grant/milestone-3/01_chain_selection_ui.md
@@ -1,0 +1,30 @@
+# 01 - Chain Selection UI
+
+Deliverable mapping: Milestone 3, Chain Selection UI.
+
+## What was delivered
+
+A `Target Chain` dropdown was added to **Step 3 (Optional Details)** of the blueprint creation wizard. Users can select between:
+
+- **Ethereum Sepolia** (chain ID `11155111`)
+- **Paseo Testnet (Polkadot)** (chain ID `420420417`)
+
+The selected chain is stored in `verifierContract.chain` on the blueprint and is used downstream by the compilation pipeline when deploying the Solidity verifier contract.
+
+The default chain was changed from Base Sepolia (`84532`) to Ethereum Sepolia (`11155111`).
+
+## Implementation Notes
+
+- **UI component:** [`src/app/create/[id]/createBlueprintSteps/EmailDetails.tsx`](../../src/app/create/%5Bid%5D/createBlueprintSteps/EmailDetails.tsx) — `<Select label="Target Chain" />` with two options.
+- **Store default:** [`src/app/create/[id]/store.ts`](../../src/app/create/%5Bid%5D/store.ts) — `verifierContract.chain` initialized to `11155111`.
+
+## Repo Evidence
+
+- Chain selector component:
+  - `src/app/create/[id]/createBlueprintSteps/EmailDetails.tsx`
+- Store default value:
+  - `src/app/create/[id]/store.ts`
+
+## Status
+
+`Delivered`

--- a/docs/kusama-grant/milestone-3/02_on_chain_verification_ui.md
+++ b/docs/kusama-grant/milestone-3/02_on_chain_verification_ui.md
@@ -1,0 +1,34 @@
+# 02 - On-Chain Verification UI
+
+Deliverable mapping: Milestone 3, On-Chain Verification UI.
+
+## What was delivered
+
+A **"Verify On-Chain"** button was added to two locations in the proof viewing flow:
+
+1. **Proof list row** (`ProofRow` component) — appears next to the existing "Verify" button in the proof table.
+2. **Proof detail page** (`/[id]/proofs/[proofId]`) — appears in the action buttons section alongside verify and download.
+
+The button is conditionally rendered only when all three conditions are true:
+- A browser wallet (`window.ethereum`) is detected.
+- The blueprint has a `verifierContract.address` set (i.e., a contract has been deployed for this blueprint).
+- The proof was generated with the Circom ZK framework (not Noir).
+
+When clicked, the button calls `blueprint.verifyProofOnChain(proof)` from `@zk-email/sdk` and shows a toast notification with the result.
+
+## Implementation Notes
+
+- **ProofRow:** [`src/app/[id]/ProofRow.tsx`](../../src/app/%5Bid%5D/ProofRow.tsx) — `onVerifyOnChain` handler, `isVerifyingOnChainLoading` state, conditional button render.
+- **Proof detail page:** [`src/app/[id]/proofs/[proofId]/page.tsx`](../../src/app/%5Bid%5D/proofs/%5BproofId%5D/page.tsx) — same pattern with a `VerifyOnChain.svg` icon.
+- The button is disabled while the proof is still `InProgress`.
+
+## Repo Evidence
+
+- ProofRow on-chain button:
+  - `src/app/[id]/ProofRow.tsx`
+- Proof detail on-chain button:
+  - `src/app/[id]/proofs/[proofId]/page.tsx`
+
+## Status
+
+`Delivered`

--- a/docs/kusama-grant/milestone-3/03_dynamic_explorer_links.md
+++ b/docs/kusama-grant/milestone-3/03_dynamic_explorer_links.md
@@ -1,0 +1,28 @@
+# 03 - Dynamic Block Explorer Links
+
+Deliverable mapping: Milestone 3, Dynamic Block Explorer Links.
+
+## What was delivered
+
+The verifier contract address link on the proof detail page now resolves to the correct block explorer based on the blueprint's target chain:
+
+| Chain ID | Chain | Explorer |
+| --- | --- | --- |
+| `11155111` | Ethereum Sepolia | `https://sepolia.etherscan.io/address/<address>` |
+| `420420417` | Paseo Testnet (Polkadot) | `https://blockscout-testnet.polkadot.io/address/<address>` |
+
+Previously, the link was hardcoded to Base Sepolia (`sepolia.basescan.org`).
+
+## Implementation Notes
+
+- **Proof detail page:** [`src/app/[id]/proofs/[proofId]/page.tsx`](../../src/app/%5Bid%5D/proofs/%5BproofId%5D/page.tsx) — an `EXPLORER_MAP` keyed by chain ID builds the correct URL from `blueprint.props.verifierContract.chain`.
+- Falls back to `#` if the chain is unrecognized or the address is not set.
+
+## Repo Evidence
+
+- Explorer link logic:
+  - `src/app/[id]/proofs/[proofId]/page.tsx` (`EXPLORER_MAP` and href computation)
+
+## Status
+
+`Delivered`

--- a/docs/kusama-grant/milestone-3/04_zk_framework_fix.md
+++ b/docs/kusama-grant/milestone-3/04_zk_framework_fix.md
@@ -1,0 +1,22 @@
+# 04 - ZK Framework Selection Fix
+
+Deliverable mapping: Milestone 3, ZK Framework Selection Fix.
+
+## What was delivered
+
+Removed a hardcoded fallback in the blueprint creation store that forced `clientZkFramework = Noir` and `serverZkFramework = SP1` when no email file was uploaded by the user. With the fix, the user's manually selected ZK framework is preserved in all cases.
+
+## Implementation Notes
+
+- **Store:** [`src/app/create/[id]/store.ts`](../../src/app/create/%5Bid%5D/store.ts) — the `else` branch that set `data.clientZkFramework = ZkFramework.Noir` and `data.serverZkFramework = ZkFramework.Sp1` was removed.
+- When an email is uploaded, `blueprint.assignPreferredZkFramework(emlStr)` still runs to auto-detect the best framework.
+- When no email is uploaded, the framework values from the store (i.e., whatever the user selected) are used without override.
+
+## Repo Evidence
+
+- Framework selection fix:
+  - `src/app/create/[id]/store.ts`
+
+## Status
+
+`Delivered`


### PR DESCRIPTION
## Summary

- Adds `docs/kusama-grant/` delivery evidence for Kusama grant Milestone 3 (frontend scope)
- Documents PolkaVM/Paseo on-chain verification UI: chain selector, Verify On-Chain buttons, dynamic explorer links, and ZK framework fix

## Changes

- `docs/kusama-grant/README.md` — index
- `docs/kusama-grant/milestone-3/00_overview.md` — milestone overview
- `docs/kusama-grant/milestone-3/01_chain_selection_ui.md` — Target Chain dropdown in blueprint creation
- `docs/kusama-grant/milestone-3/02_on_chain_verification_ui.md` — Verify On-Chain button on proof list and detail pages
- `docs/kusama-grant/milestone-3/03_dynamic_explorer_links.md` — Etherscan/Blockscout links by chain
- `docs/kusama-grant/milestone-3/04_zk_framework_fix.md` — removed hardcoded Noir/SP1 fallback