### PR TITLE
Set max header length step to 64

### DIFF
--- a/src/app/create/[id]/createBlueprintSteps/PatternDetails.tsx
+++ b/src/app/create/[id]/createBlueprintSteps/PatternDetails.tsx
@@ -210,7 +210,7 @@ const PatternDetails = ({
         errorMessage={validationErrors.description}
       />
       {/* TODO: Add check for email body max length */}
-      { (emlContent && id !== 'new') || skipEmlUpload ? null : (
+      {(emlContent && id !== 'new') || skipEmlUpload ? null : (
         <DragAndDropFile
           accept=".eml"
           file={file}
@@ -336,6 +336,7 @@ const PatternDetails = ({
         placeholder="1024"
         type="number"
         min={0}
+        step={64}
         error={!!validationErrors.emailHeaderMaxLength}
         errorMessage={
           validationErrors.emailHeaderMaxLength


### PR DESCRIPTION
Fixes #215.

## Summary
- set the Max Email Header Length number input step to 64
- leave other number inputs unchanged

## Validation
- npx prettier --check src/app/create/[id]/createBlueprintSteps/PatternDetails.tsx
- npx tsc --noEmit
- git diff --check
- npx next build --turbopack