### PR TITLE
test: add real e2e coverage for on-chain verification and proof generation (kusama_grant_paseo_e2e)

### DIFF
--- a/tests/kusama/assets/Password_reset_request.eml
+++ b/tests/kusama/assets/Password_reset_request.eml
@@ -1,0 +1,405 @@
+Delivered-To: thezdev1@gmail.com
+Received: by 2002:a05:7108:9303:b0:461:6485:79f1 with SMTP id ht3csp1293786gdb;
+        Mon, 1 Sep 2025 09:29:31 -0700 (PDT)
+X-Google-Smtp-Source: AGHT+IH/UFFCLXbmg6wOURZlahSj0/n8WDMTXEDUP0bctd3/M8qVajcCROeb3NJ6kzjnT9Sbzwr1
+X-Received: by 2002:a05:6902:2e05:b0:e96:f1e0:87a3 with SMTP id 3f1490d57ef6-e98a5838dafmr10075947276.37.1756744171363;
+        Mon, 01 Sep 2025 09:29:31 -0700 (PDT)
+ARC-Seal: i=1; a=rsa-sha256; t=1756744171; cv=none;
+        d=google.com; s=arc-20240605;
+        b=bdPmccczWdaRYLmHchVBGGJ38+XyuzZt8QLOcJ7qlVoYdEKOmysVgw6BbA+6qQJd9Y
+         2C/AF4EdRz3LJ8peWK73HsYfEa4HnbYYT6Vut65MwxkdseVb9xMF6dOr76IWxj5r1B9g
+         cSlSo7dfpXMiql1JDQ/aILOl7rHRplytpcM4PgfvTZjQgbb/RliLruqNb+KN/Y6hMg9W
+         5B6HpliN28N4Exx33bTgViudgzBub/w7O94GW/hKC2TWUbcLn7UhcznVM0GzL0ZF/6Um
+         8u/gnD21MvK6p4XVE3IJbkxTImA2GDkHrbnUOL3/agCLdIlwI+ePCpEN+FKAD9K1Dj+T
+         sjdw==
+ARC-Message-Signature: i=1; a=rsa-sha256; c=relaxed/relaxed; d=google.com; s=arc-20240605;
+        h=feedback-id:message-id:mime-version:subject:to:from:date
+         :dkim-signature;
+        bh=X/sNMmW4My0bRd2INrK90ABybPuXeOTRc/hCieehfhs=;
+        fh=fDYYgXivSc6zTOFPhUG2MdKnqwapTBkpVsOysAWOq8A=;
+        b=jnlEsdS5riV1RHOJI3jkOdSWjH4ympIAX5uZW1Yta7eNufiBRW8ag+I+NUgFXngOIb
+         Q+xeGMrhm9WHhW83HOgqNOiAMNSL9tpJBd5GSiaLOLjzNqwe8NtbKd3+fr9bSg8XaJbI
+         WxnyDZ3LhnP9jzg7mWacnawKS6lgPsjCURxM+0BuBlGl/iTYiZJpzKiOeczOjsoOUp3h
+         8i+h6N+aGkGHj6VH8V5fTzL+h6H4o0J0vdVOjNH7fSu2AS2IGSg+jVLJaZJhlZ3eM91Z
+         ZFDGTsQJk5XsHJx7M0RgCArs3Vokg9Hzh49UNgB0Dqxw8nyt+pV2kl0w8yDJcxx95OBP
+         qKLA==;
+        dara=google.com
+ARC-Authentication-Results: i=1; mx.google.com;
+       dkim=pass header.i=@x.com header.s=dkim-202308 header.b=s1ubySah;
+       spf=pass (google.com: domain of n0332a77dee-9dde0ff177a04a83-thezdev1===gmail.com@bounce.x.com designates 199.16.156.156 as permitted sender) smtp.mailfrom="n0332a77dee-9dde0ff177a04a83-thezdev1===gmail.com@bounce.x.com";
+       dmarc=pass (p=REJECT sp=REJECT dis=NONE) header.from=x.com
+Return-Path: <n0332a77dee-9dde0ff177a04a83-thezdev1===gmail.com@bounce.x.com>
+Received: from spring-chicken-aq.x.com (spring-chicken-aq.x.com. [199.16.156.156])
+        by mx.google.com with ESMTPS id 3f1490d57ef6-e98b4a1562dsi2374228276.427.2025.09.01.09.29.31
+        for <thezdev1@gmail.com>
+        (version=TLS1_2 cipher=ECDHE-ECDSA-AES128-GCM-SHA256 bits=128/128);
+        Mon, 01 Sep 2025 09:29:31 -0700 (PDT)
+Received-SPF: pass (google.com: domain of n0332a77dee-9dde0ff177a04a83-thezdev1===gmail.com@bounce.x.com designates 199.16.156.156 as permitted sender) client-ip=199.16.156.156;
+Authentication-Results: mx.google.com;
+       dkim=pass header.i=@x.com header.s=dkim-202308 header.b=s1ubySah;
+       spf=pass (google.com: domain of n0332a77dee-9dde0ff177a04a83-thezdev1===gmail.com@bounce.x.com designates 199.16.156.156 as permitted sender) smtp.mailfrom="n0332a77dee-9dde0ff177a04a83-thezdev1===gmail.com@bounce.x.com";
+       dmarc=pass (p=REJECT sp=REJECT dis=NONE) header.from=x.com
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=x.com;
+	s=dkim-202308; t=1756744171;
+	bh=X/sNMmW4My0bRd2INrK90ABybPuXeOTRc/hCieehfhs=;
+	h=Date:From:To:Subject:MIME-Version:Content-Type:Message-ID;
+	b=s1ubySahH8obUibSMQCoUzMslx/jboZmhYOuUIJ/ZLCCxWgUnXlNuvRiYevUlQQe4
+	 WSxrgSvAOQA90Yl6k4D6wAN2ERpAJlanX0ASxZ6rCB6G4XrtDMQbgdKMxdgdMA2gLU
+	 akEU2fa7BQOTshVu5cthn7h02PItM+2+9tE0w0PB9t0OTRzMpcIbSpoE8h5lYQsxLS
+	 B4DcYBWURdl0WG8i3/VrHJCJLr9DHriJ2P4+zWyHGzMSCTh8pTeTMPV47MjmTVvSYH
+	 AzopkqQEBVAzKaq1zXIB7eMYROHCsqFkxIZdKM0bIYMajfWs0/nFUeC21u682kVjtL
+	 BKBuuZswQK3cA==
+X-MSFBL: e8vtd3BILFqH2IvnV5S4VulZil0SVaOlUOD8HR7iR6A=|eyJyIjoidGhlemRldjF
+	AZ21haWwuY29tIiwiZyI6IkJ1bGsiLCJiIjoiYXRsYS1hdmYtMjYtc3IxLUJ1bGs
+	uMTc2IiwidSI6InRoZXpkZXYxQGdtYWlsLmNvbUBpaWQjIzlkZGUwZmYxNzdhMDR
+	hODNhOTI1M2ZlNjdlZGZlN2FlQHVzYiMjMjRAMjk2QDE5MzU2NTYyMTcwODQ1ODg
+	wMzJAMEA2ZWRmZTRjNGY2ODI4ZTIzYTRiZmJmOGQ1MGJiMDExOWY2MTI5NGJlIn0
+	=
+Date: Mon, 01 Sep 2025 16:29:31 +0000
+From: X <info@x.com>
+To: zdev <thezdev1@gmail.com>
+Subject: Password reset request
+MIME-Version: 1.0
+Content-Type: multipart/alternative; 
+	boundary="----=_Part_3025541_1395592566.1756744171230"
+X-Twitter-CID: ibis2-password_reset_pin_based_email
+Message-ID: <05.F8.29743.BE9C5B86@x.com>
+Feedback-ID: atla.c5bbd1c7e491b5023ff4b22a03711997:X
+
+------=_Part_3025541_1395592566.1756744171230
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+X
+
+Reset your password?
+
+If you requested a password reset for thezdev1, use the confirmation code below to complete the process. If you didn't make this request, ignore this email.
+
+> 9xpq92m4
+
+
+Getting a lot of password reset emails?
+You can change your account settings to require personal information to reset your password.
+
+account settings
+> https://x.com/settings/security
+
+------------------------
+Help
+> https://support.x.com/articles/14663
+
+Not my account
+> https://twitter.com/account/not_my_account/1935656217084588032/HF353-9265C-175674?ut=1&amp;cn=cGFzc3dvcmRfcmVzZXRfcGluX2Jhc2VkX2VtYWls
+
+Email security tips
+> https://help.x.com/safety-and-security/fake-x-emails
+
+X Corp. 1355 Market Street, Suite 900 San Francisco, CA 94103
+
+------=_Part_3025541_1395592566.1756744171230
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www=
+.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+<head>
+<meta http-equiv=3D"Content-Type" content=3D"text/html; charset=3Dutf-8" />
+<meta name=3D"viewport" content=3D"width=3Ddevice-width, minimum-scale=3D1.=
+0, maximum-scale=3D1.0, user-scalable=3D0" />
+<meta name=3D"apple-mobile-web-app-capable" content=3D"yes" />
+<style type=3D"text/css">
+@media only screen and (max-width: 320px) {
+table[class=3D"edu-module"]{
+border-radius: 0px !important;
+-webkit-border-radius: 0px !important;
+-moz-border-radius: 0px !important;
+}
+td[class=3D"edu-collapse"]{
+width: 0px !important;
+}
+td[class=3D"mobile-height"]{
+height: 30px !important;
+}
+}
+@media only screen and (max-width: 420px) {
+td[class=3D"spacer"]{
+font-size:4px !important;
+}
+span[class=3D"address"] a {
+line-height:18px !important;
+}
+a[class=3D"cut"]{
+display:none !important;
+}
+td[class=3D"margins"]{
+width:18px !important;
+}
+td[class=3D"edu-margins"]{
+width:18px !important;
+}
+td[class=3D"logo_space"]{
+height:12px !important;
+}
+}
+@media only screen and (max-width: 480px) {
+table[class=3D"collapse"]{
+width:100% !important;
+}
+table[class=3D"edu-module"]{
+width:100% !important;
+}
+div[class=3D"collapse"]{
+width:100% !important;
+}
+td[class=3D"logo_space"]{
+height: 24px !important;
+}
+span[class=3D"address"]{
+display:block !important;
+width:240px !important;
+}
+td[class=3D"cut"]{
+display:none !important;
+}
+td[class=3D"logo"] img {
+width:24px !important;
+}
+span[class=3D"address"] a {
+line-height:18px !important;
+}
+}
+</style>
+</head>
+<body bgcolor=3D"#F5F8FA" style=3D"margin:0;padding:0;-webkit-text-size-adj=
+ust:100%;-ms-text-size-adjust:100%;">
+<table cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%" bgco=
+lor=3D"#F5F8FA" style=3D"background-color:#F5F8FA;padding:0;margin:0;line-h=
+eight:1px;font-size:1px;" class=3D"body_wrapper">
+<tbody>
+<tr>
+<td align=3D"center" style=3D"padding:0;margin:0;line-height:1px;font-size:=
+1px;">
+<table class=3D"collapse" id=3D"header" align=3D"center" width=3D"448" styl=
+e=3D"width: 448px;padding:0;margin:0;line-height:1px;font-size:1px;" bgcolo=
+r=3D"#ffffff" cellpadding=3D"0" cellspacing=3D"0" border=3D"0">
+<tbody>
+<tr>
+<td style=3D"min-width: 448px;padding:0;margin:0;line-height:1px;font-size:=
+1px;" class=3D"cut"> <img src=3D"https://ea.twimg.com/email/self_serve/medi=
+a/spacer-1402696023930.png" style=3D"min-width: 448px;height:1px;margin:0;p=
+adding:0;display:block;-ms-interpolation-mode:bicubic;border:none;outline:n=
+one;" /> </td>
+</tr>
+</tbody>
+</table> </td>
+</tr>
+<tr>
+<td align=3D"center" style=3D"padding:0;margin:0;line-height:1px;font-size:=
+1px;">
+<!--/////////////////// header ///////////////////////////-->
+<table class=3D"collapse" id=3D"header" align=3D"center" width=3D"448" styl=
+e=3D"width:448px;background-color:#ffffff;padding:0;margin:0;line-height:1p=
+x;font-size:1px;" bgcolor=3D"#ffffff" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0">
+<tbody>
+<tr>
+<td colspan=3D"4" height=3D"24" style=3D"height:24px;padding:0;margin:0;lin=
+e-height:1px;font-size:1px;" class=3D"logo_space"> &nbsp; </td>
+</tr>
+<tr align=3D"right">
+<td width=3D"24" class=3D"margin" style=3D"padding:0;margin:0;line-height:1=
+px;font-size:1px;"></td>
+<td align=3D"right" style=3D"padding:0;margin:0;line-height:1px;font-size:1=
+px;"> <a href=3D"#" target=3D"blank" style=3D"text-decoration:none;border-s=
+tyle:none;border:0;padding:0;margin:0;"> <img width=3D"32" align=3D"right" =
+src=3D"https://ton.x.com/twitter_blue_for_business/verified-programs/x_logo=
+.png" style=3D"width:32px;margin:0;padding:0;display:block;-ms-interpolatio=
+n-mode:bicubic;border:none;outline:none;" /> </a> </td>
+<td width=3D"24" class=3D"margin" style=3D"padding:0;margin:0;line-height:1=
+px;font-size:1px;"></td>
+</tr>
+<tr>
+<td colspan=3D"3" height=3D"24" style=3D"height:24px;padding:0;margin:0;lin=
+e-height:1px;font-size:1px;" class=3D"logo_space"> <img width=3D"1" height=
+=3D"1" style=3D"display: block;margin:0;padding:0;display:block;-ms-interpo=
+lation-mode:bicubic;border:none;outline:none;" src=3D"https://twitter.com/s=
+cribe/ibis?t=3D1&amp;cn=3DcGFzc3dvcmRfcmVzZXRfcGluX2Jhc2VkX2VtYWls&amp;iid=
+=3D9dde0ff177a04a83a9253fe67edfe7ae&amp;uid=3D1935656217084588032&amp;nid=
+=3D296+20" /> </td>
+</tr>
+</tbody>
+</table>
+<!--/////////////////// end header///////////////////////////-->
+<!--/////////////////// body ///////////////////////////-->
+<table class=3D"collapse" id=3D"header" align=3D"center" width=3D"448" styl=
+e=3D"width:448px;background-color:#ffffff;padding:0;margin:0;line-height:1p=
+x;font-size:1px;" bgcolor=3D"#ffffff" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0">
+<tbody>
+<tr align=3D"left;">
+<td width=3D"24" class=3D"margin" style=3D"padding:0;margin:0;line-height:1=
+px;font-size:1px;"></td>
+<td align=3D"left;" style=3D"padding:0;margin:0;line-height:1px;font-size:1=
+px;">
+<table class=3D"collapse" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" =
+style=3D"padding:0;margin:0;line-height:1px;font-size:1px;">
+<tbody>
+<tr>
+<td align=3D"left;" class=3D"h2" style=3D"padding:0;margin:0;line-height:1p=
+x;font-size:1px;font-family:'HelveticaNeue', 'Helvetica Neue', Helvetica, A=
+rial, sans-serif;font-size:24px;line-height:32px;font-weight:bold;color:#29=
+2F33;text-align:left;text-decoration:none;-webkit-font-smoothing:antialiase=
+d;"> Reset your password? </td>
+</tr>
+<tr>
+<td height=3D"12" style=3D"padding:0;margin:0;line-height:1px;font-size:1px=
+;"></td>
+</tr>
+<tr>
+<td align=3D"left;" class=3D"body-text" style=3D"padding:0;margin:0;line-he=
+ight:1px;font-size:1px;font-family:'HelveticaNeue', 'Helvetica Neue', Helve=
+tica, Arial, sans-serif;font-size:16px;line-height:20px;font-weight:400;col=
+or:#292F33;text-align:left;text-decoration:none;-webkit-font-smoothing:anti=
+aliased;"> If you requested a password reset for @thezdev1, use the confirm=
+ation code below to complete the process. If you didn't make this request, =
+ignore this email. </td>
+</tr>
+<tr>
+<td height=3D"24" style=3D"padding:0;margin:0;line-height:1px;font-size:1px=
+;"></td>
+</tr>
+<!--*********** password reset pin ************-->
+<tr>
+<td align=3D"left;" class=3D"support" style=3D"padding:0;margin:0;line-heig=
+ht:1px;font-size:1px;font-family:'HelveticaNeue', 'Helvetica Neue', Helveti=
+ca, Arial, sans-serif;font-size:14px;line-height:16px;font-weight:400;color=
+:#292F33;text-align:left;text-decoration:none;-webkit-font-smoothing:antial=
+iased;"> <strong>9xpq92m4</strong> </td>
+</tr>
+<!--*********** end password reset pin ************-->
+<tr>
+<td height=3D"36" style=3D"height:36px;padding:0;margin:0;line-height:1px;f=
+ont-size:1px;"></td>
+</tr>
+<tr>
+<td align=3D"left;" class=3D"body-text" style=3D"padding:0;margin:0;line-he=
+ight:1px;font-size:1px;font-family:'HelveticaNeue', 'Helvetica Neue', Helve=
+tica, Arial, sans-serif;font-size:16px;line-height:20px;font-weight:400;col=
+or:#292F33;text-align:left;text-decoration:none;-webkit-font-smoothing:anti=
+aliased;"> <strong>Getting a lot of password reset emails?</strong> </td>
+</tr>
+<tr>
+<td height=3D"12" style=3D"padding:0;margin:0;line-height:1px;font-size:1px=
+;"></td>
+</tr>
+<tr>
+<td align=3D"left;" class=3D"body-text" style=3D"padding:0;margin:0;line-he=
+ight:1px;font-size:1px;font-family:'HelveticaNeue', 'Helvetica Neue', Helve=
+tica, Arial, sans-serif;font-size:16px;line-height:20px;font-weight:400;col=
+or:#292F33;text-align:left;text-decoration:none;-webkit-font-smoothing:anti=
+aliased;"> You can change your <a href=3D"https://t.co/redirect?url=3Dhttps=
+%3A%2F%2Fx.com%2Fsettings%2Fsecurity&amp;t=3D1&amp;cn=3DcGFzc3dvcmRfcmVzZXR=
+fcGluX2Jhc2VkX2VtYWls&amp;sig=3D9b7742c0e7a1779c8ce51e28b1b0a8f35271c1d8&am=
+p;iid=3D9dde0ff177a04a83a9253fe67edfe7ae&amp;uid=3D1935656217084588032&amp;=
+nid=3D296+3" style=3D"text-decoration:none;border-style:none;border:0;paddi=
+ng:0;margin:0;border:none;text-decoration:none;font-weight:400;color:#1DA1F=
+2;">account settings</a> to require personal information to reset your pass=
+word. </td>
+</tr>
+<tr>
+<td height=3D"36" style=3D"padding:0;margin:0;line-height:1px;font-size:1px=
+;"></td>
+</tr>
+</tbody>
+</table> </td>
+<td width=3D"24" class=3D"margin" style=3D"padding:0;margin:0;line-height:1=
+px;font-size:1px;"></td>
+</tr>
+</tbody>
+</table>
+<!--/////////////////// end body///////////////////////////-->
+<!--///////////////////// footer /////////////////////-->
+<table class=3D"collapse" id=3D"footer" align=3D"center" width=3D"448" styl=
+e=3D"width:448px; background-color:#ffffff;padding:0;margin:0;line-height:1=
+px;font-size:1px;" cellpadding=3D"0" cellspacing=3D"0" border=3D"0">
+<tbody>
+<tr>
+<td height=3D"36" style=3D"height:36px;padding:0;margin:0;line-height:1px;f=
+ont-size:1px;"></td>
+</tr>
+<tr>
+<td align=3D"center" style=3D"padding:0;margin:0;line-height:1px;font-size:=
+1px;"> <span class=3D"small-copy" style=3D"font-family:'HelveticaNeue', 'He=
+lvetica Neue', Helvetica, Arial, sans-serif;font-size:12px;line-height:16px=
+;font-weight:400;color:#8899A6;text-align:left;text-decoration:none;-webkit=
+-font-smoothing:antialiased;"> <a href=3D"https://support.x.com/articles/14=
+663" class=3D"small-copy" style=3D"text-decoration:none;border-style:none;b=
+order:0;padding:0;margin:0;font-family:'HelveticaNeue', 'Helvetica Neue', H=
+elvetica, Arial, sans-serif;font-size:12px;line-height:16px;font-weight:400=
+;color:#8899A6;text-align:left;text-decoration:none;-webkit-font-smoothing:=
+antialiased;font-family:'HelveticaNeue', 'Helvetica Neue', Helvetica, Arial=
+, sans-serif;font-size:12px;line-height:16px;font-weight:600;color:#1DA1F2;=
+text-align:left;text-decoration:none;-webkit-font-smoothing:antialiased;">H=
+elp</a> &nbsp;|&nbsp; <a href=3D"https://twitter.com/account/not_my_account=
+/1935656217084588032/HF353-9265C-175674?ut=3D1&amp;cn=3DcGFzc3dvcmRfcmVzZXR=
+fcGluX2Jhc2VkX2VtYWls" class=3D"small-copy" style=3D"text-decoration:none;b=
+order-style:none;border:0;padding:0;margin:0;font-family:'HelveticaNeue', '=
+Helvetica Neue', Helvetica, Arial, sans-serif;font-size:12px;line-height:16=
+px;font-weight:400;color:#8899A6;text-align:left;text-decoration:none;-webk=
+it-font-smoothing:antialiased;font-family:'HelveticaNeue', 'Helvetica Neue'=
+, Helvetica, Arial, sans-serif;font-size:12px;line-height:16px;font-weight:=
+600;color:#1DA1F2;text-align:left;text-decoration:none;-webkit-font-smoothi=
+ng:antialiased;">Not my account</a> &nbsp;|&nbsp; <a href=3D"https://t.co/r=
+edirect?url=3Dhttps%3A%2F%2Fhelp.x.com%2Fsafety-and-security%2Ffake-x-email=
+s&amp;t=3D1&amp;cn=3DcGFzc3dvcmRfcmVzZXRfcGluX2Jhc2VkX2VtYWls&amp;sig=3Da17=
+6b9489f6281dfbdf2613fe5fef958ff361172&amp;iid=3D9dde0ff177a04a83a9253fe67ed=
+fe7ae&amp;uid=3D1935656217084588032&amp;nid=3D296+6" class=3D"small-copy" s=
+tyle=3D"text-decoration:none;border-style:none;border:0;padding:0;margin:0;=
+font-family:'HelveticaNeue', 'Helvetica Neue', Helvetica, Arial, sans-serif=
+;font-size:12px;line-height:16px;font-weight:400;color:#8899A6;text-align:l=
+eft;text-decoration:none;-webkit-font-smoothing:antialiased;font-family:'He=
+lveticaNeue', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:12px=
+;line-height:16px;font-weight:600;color:#1DA1F2;text-align:left;text-decora=
+tion:none;-webkit-font-smoothing:antialiased;">Email security tips</a> </sp=
+an> </td>
+</tr>
+<tr>
+<td height=3D"12" style=3D"height:12px;line-height:1px;font-size:1px;paddin=
+g:0;margin:0;line-height:1px;font-size:1px;"></td>
+</tr>
+<tr>
+<td align=3D"center" style=3D"padding:0;margin:0;line-height:1px;font-size:=
+1px;"> <span class=3D"small-copy" style=3D"font-family:'HelveticaNeue', 'He=
+lvetica Neue', Helvetica, Arial, sans-serif;font-size:12px;line-height:16px=
+;font-weight:400;color:#8899A6;text-align:left;text-decoration:none;-webkit=
+-font-smoothing:antialiased;"> This email was meant for @thezdev1 </span> <=
+/td>
+</tr>
+<tr>
+<td height=3D"6" style=3D"height:6px;line-height:1px;font-size:1px;padding:=
+0;margin:0;line-height:1px;font-size:1px;"></td>
+</tr>
+<tr>
+<td align=3D"center" style=3D"padding:0;margin:0;line-height:1px;font-size:=
+1px;"> <span class=3D"address"> <a href=3D"#" style=3D"text-decoration:none=
+;border-style:none;border:0;padding:0;margin:0;font-family:'HelveticaNeue',=
+ 'Helvetica Neue', Helvetica, Arial, sans-serif;-webkit-font-smoothing:anti=
+aliased;color:#8899A6;font-size:12px;padding:0px;margin:0px;font-weight:nor=
+mal;line-height:12px;cursor:default;">X Corp. 1355 Market Street, Suite 900=
+ San Francisco, CA 94103</a> </span> </td>
+</tr>
+<tr>
+<td height=3D"72" style=3D"height:72px;padding:0;margin:0;line-height:1px;f=
+ont-size:1px;"></td>
+</tr>
+</tbody>
+</table>
+<!--///////////////////// end footer /////////////////////--> </td>
+</tr>
+</tbody>
+</table>
+</body>
+</html>
+------=_Part_3025541_1395592566.1756744171230--

--- a/tests/kusama/generateProof.ts
+++ b/tests/kusama/generateProof.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test';
+import { dragAndDropFile } from '../../src/test-utils/DragAndDropFile';
+
+test('test proof generation for kusama_grant_paseo_e2e', async ({ page }) => {
+  // Real circom proving takes ~2 min on staging.
+  test.setTimeout(5 * 60 * 1000);
+
+  // zkemailverify/kusama_grant_paseo_e2e: compiled and deployed to Paseo through
+  // the current pipeline (unlike test_0001_2, exercised by ../generateProof.ts,
+  // which predates it). Navigated by id directly, same reasoning as that test.
+  await page.goto('http://localhost:3000/e94e7f93-7575-4e26-a147-de894b19ce3e');
+  await page.waitForLoadState('networkidle');
+
+  // check the connect emails page
+  await expect(page.getByRole('heading', { name: 'Connect emails' })).toBeVisible();
+
+  // upload the email file. We need another component for this. https://stackoverflow.com/a/77738836
+  await dragAndDropFile(
+    page,
+    '#drag-and-drop-emails',
+    'tests/kusama/assets/Password_reset_request.eml',
+    'Password_reset_request.eml'
+  );
+
+  await expect(page.locator('#uploadedFile')).toBeVisible();
+  await page.locator('#uploadedFile').click();
+  // This blueprint has no external inputs, so it goes straight to the proving-mode
+  // choice - no "Add Inputs" step in between.
+  await page.getByTestId('remote-proving').click();
+
+  await expect(page.getByRole('heading', { name: 'View Proof' })).toBeVisible({
+    timeout: 4 * 60 * 1000,
+  });
+  await expect(
+    page.locator('div').filter({ hasText: 'View ProofPlease standby,' }).nth(3)
+  ).toBeVisible();
+  await expect(page.getByText('{"email_sender": ["info@x.com"')).toBeVisible();
+  await expect(page.getByRole('img', { name: 'status' })).toBeVisible();
+  await expect(page.getByText('{"email_sender": ["info@x.com"')).toBeVisible();
+  await expect(page.getByRole('button', { name: '| View' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'download' })).toBeVisible();
+
+  await page.getByRole('button', { name: '| View' }).click();
+  await page.waitForLoadState('networkidle');
+
+  await expect(page.locator('#job-id')).toBeVisible();
+  await expect(page.locator('#job-id')).not.toBeNull();
+  await expect(page.locator('#blueprint-title')).not.toHaveText('-');
+  await expect(page.locator('#outputs')).not.toHaveText('-');
+  await expect(page.locator('#date-created')).not.toHaveText('-');
+  await expect(page.locator('#time-taken')).not.toHaveText('-');
+  await expect(page.locator('#status')).not.toHaveText('-');
+  await expect(page.getByRole('button', { name: 'Share proof Share Proof' })).toBeVisible();
+  await expect(page.locator('div').filter({ hasText: '{ "pi_a": [ "' }).nth(3)).toBeVisible();
+
+  // Confirms the verifier this proof would be checked against is deployed to
+  // Paseo specifically, not just some address.
+  const verifierLink = page.locator('a', {
+    hasText: '0x72616B78d29d0cccBfEec1bf00E108885286D2f3',
+  });
+  await expect(verifierLink).toBeVisible();
+  await expect(verifierLink).toHaveAttribute('href', /blockscout-testnet\.polkadot\.io/);
+});

--- a/tests/kusama/verifyProofOnChain.ts
+++ b/tests/kusama/verifyProofOnChain.ts
@@ -13,19 +13,20 @@ test('verify a real proof on-chain against a deployed Paseo verifier', async ({ 
     (window as any).ethereum = { isMetaMask: true, request: async () => null };
   });
 
-  // zkemailverify/test_0001_2 (same blueprint as tests/generateProof.ts), proof
-  // id for a real, already-completed remote proof with a Paseo verifier deployed.
-  // Reused rather than generating a fresh proof each run (that's already covered
-  // by tests/generateProof.ts).
+  // zkemailverify/kusama_grant_paseo_e2e: compiled and deployed to Paseo through
+  // the current pipeline (not test_0001_2, which predates it). Proof id for a
+  // real, already-completed remote proof against its deployed verifier. Reused
+  // rather than generating a fresh one each run (that's covered by
+  // tests/kusama/generateProof.ts).
   await page.goto(
-    'http://localhost:3000/f63c7198-76b1-413c-b785-7655ebdaaec1/proofs/a19c659c-8224-4cb1-b503-cfc4511566c4'
+    'http://localhost:3000/e94e7f93-7575-4e26-a147-de894b19ce3e/proofs/fece17c3-f3ed-4833-bbf9-eccdf530d474'
   );
   await page.waitForLoadState('networkidle');
 
   // Confirms the verifier is deployed and resolves to the correct (Paseo) explorer,
   // not just that some address string is present.
   const verifierLink = page.locator('a', {
-    hasText: '0xEf6B5496Bd6D13E2A518eA7961aA1Df1F41Db033',
+    hasText: '0x72616B78d29d0cccBfEec1bf00E108885286D2f3',
   });
   await expect(verifierLink).toBeVisible();
   await expect(verifierLink).toHaveAttribute('href', /blockscout-testnet\.polkadot\.io/);

--- a/tests/verifyProofOnChain.ts
+++ b/tests/verifyProofOnChain.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+
+test('verify a real proof on-chain against a deployed Paseo verifier', async ({ page }) => {
+  // Page load triggers two API calls (getBlueprintById, getProofIdsForBlueprint)
+  // before the button even renders, plus a real RPC call to Paseo on click.
+  test.setTimeout(60 * 1000);
+
+  // The "Verify On-Chain" button only renders when window.ethereum is present
+  // (see src/app/[id]/proofs/[proofId]/page.tsx `hasWallet`). The verification
+  // call itself uses a plain viem public client (readContract), not the
+  // injected provider, so a minimal stub is enough to satisfy the gate.
+  await page.addInitScript(() => {
+    (window as any).ethereum = { isMetaMask: true, request: async () => null };
+  });
+
+  // zkemailverify/test_0001_2 (same blueprint as tests/generateProof.ts), proof
+  // id for a real, already-completed remote proof with a Paseo verifier deployed.
+  // Reused rather than generating a fresh proof each run (that's already covered
+  // by tests/generateProof.ts).
+  await page.goto(
+    'http://localhost:3000/f63c7198-76b1-413c-b785-7655ebdaaec1/proofs/a19c659c-8224-4cb1-b503-cfc4511566c4'
+  );
+  await page.waitForLoadState('networkidle');
+
+  // Confirms the verifier is deployed and resolves to the correct (Paseo) explorer,
+  // not just that some address string is present.
+  const verifierLink = page.locator('a', {
+    hasText: '0xEf6B5496Bd6D13E2A518eA7961aA1Df1F41Db033',
+  });
+  await expect(verifierLink).toBeVisible();
+  await expect(verifierLink).toHaveAttribute('href', /blockscout-testnet\.polkadot\.io/);
+
+  await page.getByRole('button', { name: 'Verify On-Chain' }).click();
+  await expect(page.getByText('Proof verified successfully on chain')).toBeVisible({
+    timeout: 30 * 1000,
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `tests/kusama/verifyProofOnChain.ts`: navigates to a real, already-completed proof for the `kusama_grant_paseo_e2e` blueprint (compiled/deployed to Paseo through the current pipeline), clicks "Verify On-Chain", asserts the verifier address resolves to Blockscout/Paseo specifically and that verification succeeds.
- Adds `tests/kusama/generateProof.ts`: fresh remote proof generation against the same blueprint, mirroring `tests/generateProof.ts`'s pattern.
- Kept as a separate blueprint/fixture/directory (`tests/kusama/`) rather than repointing the existing `test_0001_2`-based tests, so general regression coverage stays decoupled from anything grant-specific.

## Test plan
- [x] Both tests confirmed passing locally against staging.
- [x] CI green on this PR.