### PR TITLE
chore: disable/remove legacy non-working options

### DIFF
--- a/src/app/[id]/SelectEmails.tsx
+++ b/src/app/[id]/SelectEmails.tsx
@@ -464,7 +464,7 @@ const SelectEmails = ({ id }: { id: string }) => {
                   temporarily and then deleted right after the proof creation.
                 </p>
               </div>
-              <div
+              {/* <div
                 data-testid="local-proving"
                 className={`rounded-2xl border border-grey-200 p-6 ${
                   selectedEmail === null ||
@@ -511,7 +511,7 @@ const SelectEmails = ({ id }: { id: string }) => {
                     'Local proving only works for blueprints compiled with Circom'
                   )}
                 </p>
-              </div>
+              </div> */}
             </div>
           )}
         </div>

--- a/src/app/create/[id]/createBlueprintSteps/EmailDetails.tsx
+++ b/src/app/create/[id]/createBlueprintSteps/EmailDetails.tsx
@@ -226,7 +226,7 @@ const EmailDetails = ({
           />
         </div>
       )}
-      <Select
+      {/* <Select
         label="Client Zk Framework"
         value={store.clientZkFramework}
         onChange={async (value) => {
@@ -257,7 +257,7 @@ const EmailDetails = ({
           ]
           // : [{ label: 'Circom', value: ZkFramework.Circom }]
         }
-      />
+      /> */}
       {store.clientZkFramework === ZkFramework.Noir && detectedKeyBitLength && (
         <div className="flex w-full flex-row items-center gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3">
           <InfoIcon className="h-5 w-5 flex-shrink-0 text-blue-600" />

--- a/src/app/create/[id]/createBlueprintSteps/EmailDetails.tsx
+++ b/src/app/create/[id]/createBlueprintSteps/EmailDetails.tsx
@@ -288,14 +288,7 @@ const EmailDetails = ({
           console.log('setting serverzkframework to ', value);
           setField('serverZkFramework', value);
         }}
-        options={
-          process.env.NEXT_PUBLIC_DEPLOYMENT_ENV === 'staging'
-            ? [
-                { label: 'SP1', value: ZkFramework.Sp1 },
-                { label: 'Circom', value: ZkFramework.Circom },
-              ]
-            : [{ label: 'Circom', value: ZkFramework.Circom }]
-        }
+        options={[{ label: 'Circom', value: ZkFramework.Circom }]}
       />
     </div>
   );

--- a/src/app/create/[id]/createBlueprintSteps/EmailDetails.tsx
+++ b/src/app/create/[id]/createBlueprintSteps/EmailDetails.tsx
@@ -269,6 +269,16 @@ const EmailDetails = ({
       )}
 
       <Select
+        label="Server Zk Framework"
+        value={store.serverZkFramework}
+        onChange={(value) => {
+          console.log('setting serverzkframework to ', value);
+          setField('serverZkFramework', value);
+        }}
+        options={[{ label: 'Circom', value: ZkFramework.Circom }]}
+      />
+
+      <Select
         label="Target Chain"
         value={store.verifierContract?.chain ?? 84532}
         onChange={(value) => {
@@ -279,16 +289,6 @@ const EmailDetails = ({
           { label: 'Ethereum Sepolia', value: 11155111 },
           { label: 'Paseo Testnet (Polkadot)', value: 420420417 },
         ]}
-      />
-
-      <Select
-        label="Server Zk Framework"
-        value={store.serverZkFramework}
-        onChange={(value) => {
-          console.log('setting serverzkframework to ', value);
-          setField('serverZkFramework', value);
-        }}
-        options={[{ label: 'Circom', value: ZkFramework.Circom }]}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Hide the "Client Zk Framework" selector on blueprint creation step 2 (only Noir was ever offered/working there)
- Remove SP1 as a "Server Zk Framework" option (non-working legacy option)
- Hide "Local Proving" on the Select Emails page, leaving only Remote Proving
- Reorder step 2 fields so "Server Zk Framework" appears above "Target Chain"

## Test plan
- [x] Verify blueprint creation step 2 no longer shows a Client Zk Framework dropdown
- [x] Verify Server Zk Framework selector only offers Circom, and appears above Target Chain
- [x] Verify the proof generation page only shows Remote Proving