### PR TITLE
chore: bump @zk-email/sdk to 3.0.0-nightly.30

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
         "@radix-ui/react-switch": "^1.1.1",
         "@radix-ui/react-tooltip": "^1.1.6",
         "@react-oauth/google": "^0.12.1",
-        "@zk-email/sdk": "3.0.0-nightly.22",
+        "@zk-email/sdk": "3.0.0-nightly.30",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "crypto": "^1.0.1",
@@ -425,7 +425,7 @@
 
     "@zk-email/relayer-utils": ["@zk-email/relayer-utils@0.4.66-18", "", {}, "sha512-uWznGyFs3yiaZHLlwdHiH/Ao1jETHeIEF4Qfrkl6MMZbAEeXEHJiMTldCn7mkGnks3pCG/Rv2nBU1vK1752IBQ=="],
 
-    "@zk-email/sdk": ["@zk-email/sdk@3.0.0-nightly.22", "", { "dependencies": { "@azure/msal-browser": "^4.5.1", "@mach-34/noir-bignum-paramgen": "^1.1.2", "@peculiar/webcrypto": "^1.5.0", "@zk-email/relayer-utils": "0.4.66-18", "@zk-email/snarkjs": "^0.0.1", "ethers": "^6.13.4", "jszip": "^3.10.1", "poseidon-lite": "^0.3.0", "rsa-key": "^0.0.6", "snarkjs": "^0.7.5", "viem": "^2.21.53", "zod": "^3.23.8" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-PDwPSaLS90SPa3g3zKOn4CIsW5LMbsWLe2JJeru4unBMD3npYvntc84xPXPlKgrnX9sjZuMrF8T5fBQyhMxSeA=="],
+    "@zk-email/sdk": ["@zk-email/sdk@3.0.0-nightly.30", "", { "dependencies": { "@azure/msal-browser": "^4.5.1", "@mach-34/noir-bignum-paramgen": "^1.1.2", "@peculiar/webcrypto": "^1.5.0", "@zk-email/relayer-utils": "0.4.66-18", "@zk-email/snarkjs": "^0.0.1", "ethers": "^6.13.4", "jszip": "^3.10.1", "poseidon-lite": "^0.3.0", "rsa-key": "^0.0.6", "snarkjs": "^0.7.5", "viem": "^2.21.53", "zod": "^3.23.8" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-/2h9wR3zwXDbRzRNAq0f1+QNLbgqNADOAEm2X9ik1mdeFOv0wbc/suAIzP5VGDcWAp/0dMJ/Ojl5QkGauxI6ow=="],
 
     "@zk-email/snarkjs": ["@zk-email/snarkjs@0.0.1", "", { "dependencies": { "@iden3/binfileutils": "0.0.12", "bfj": "^7.0.2", "blake2b-wasm": "^2.4.0", "circom_runtime": "0.1.28", "ejs": "^3.1.6", "fastfile": "0.0.20", "ffjavascript": "0.3.1", "js-sha3": "^0.8.0", "logplease": "^1.2.15", "r1csfile": "0.0.48" }, "bin": { "snarkjs": "build/cli.cjs" } }, "sha512-QJ2GfP4C5AW7gAshxHeToLwLdRy1hMiTMaL9AqJiW9hQ2zDD5gMFdav79q7Jwm3h42kzU3A+Na9zqpDr3Iue2w=="],
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@radix-ui/react-switch": "^1.1.1",
     "@radix-ui/react-tooltip": "^1.1.6",
     "@react-oauth/google": "^0.12.1",
-    "@zk-email/sdk": "3.0.0-nightly.22",
+    "@zk-email/sdk": "3.0.0-nightly.30",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "crypto": "^1.0.1",

--- a/tests/kusama/targetChainSelector.ts
+++ b/tests/kusama/targetChainSelector.ts
@@ -8,7 +8,13 @@ test('Target Chain dropdown offers and preserves Paseo Testnet (Polkadot)', asyn
   // "zktestman00", exp 2046-01-01 (see PR #311, commit 0303e60 - the version
   // that shipped in blueprintCreation.ts itself was later reverted back to
   // the expired one when that test got skipped, so don't copy it from there).
-  await page.goto('http://localhost:3000/');
+  //
+  // Uses addInitScript instead of an evaluate() call after an initial
+  // navigation to "/": addInitScript runs before any page script on every
+  // subsequent navigation, so the app's very first render already has
+  // auth-storage populated, instead of racing the app's own hydration
+  // against a localStorage write that lands after the page has started
+  // loading.
   const authStorage = {
     state: {
       username: 'zktestman00',
@@ -18,7 +24,7 @@ test('Target Chain dropdown offers and preserves Paseo Testnet (Polkadot)', asyn
     },
     version: 0,
   };
-  await page.evaluate((storage) => {
+  await page.addInitScript((storage) => {
     localStorage.setItem('auth-storage', storage);
   }, JSON.stringify(authStorage));
 


### PR DESCRIPTION
## Summary
- Bumps `@zk-email/sdk` from `3.0.0-nightly.22` to `3.0.0-nightly.30`
- Picks up zkemail/zk-email-sdk-js#98 (fixes real proof generation, broken by an unnoticed relayer-utils version regression), #97 (disables Noir/SP1/local proving at the SDK level, matching this repo's own already-disabled UI options), and #99 (fixes an SSR crypto-browserify bundling crash)
- Fixes `tests/kusama/targetChainSelector.ts`, which started failing after the bump: switches auth injection from `page.evaluate()` (after an initial navigation) to `page.addInitScript()`, which runs before any page script on every navigation - removing a race against the app's own hydration instead of trying to wait it out. Confirmed via isolated CI runs that this one change is what fixes it.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] CI Playwright suite: 6/6 pass