### PR TITLE
chore: bump @zk-email/sdk to 3.0.0-nightly.34

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
         "@radix-ui/react-switch": "^1.1.1",
         "@radix-ui/react-tooltip": "^1.1.6",
         "@react-oauth/google": "^0.12.1",
-        "@zk-email/sdk": "3.0.0-nightly.30",
+        "@zk-email/sdk": "3.0.0-nightly.34",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "crypto": "^1.0.1",
@@ -425,7 +425,7 @@
 
     "@zk-email/relayer-utils": ["@zk-email/relayer-utils@0.4.66-18", "", {}, "sha512-uWznGyFs3yiaZHLlwdHiH/Ao1jETHeIEF4Qfrkl6MMZbAEeXEHJiMTldCn7mkGnks3pCG/Rv2nBU1vK1752IBQ=="],
 
-    "@zk-email/sdk": ["@zk-email/sdk@3.0.0-nightly.30", "", { "dependencies": { "@azure/msal-browser": "^4.5.1", "@mach-34/noir-bignum-paramgen": "^1.1.2", "@peculiar/webcrypto": "^1.5.0", "@zk-email/relayer-utils": "0.4.66-18", "@zk-email/snarkjs": "^0.0.1", "ethers": "^6.13.4", "jszip": "^3.10.1", "poseidon-lite": "^0.3.0", "rsa-key": "^0.0.6", "snarkjs": "^0.7.5", "viem": "^2.21.53", "zod": "^3.23.8" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-/2h9wR3zwXDbRzRNAq0f1+QNLbgqNADOAEm2X9ik1mdeFOv0wbc/suAIzP5VGDcWAp/0dMJ/Ojl5QkGauxI6ow=="],
+    "@zk-email/sdk": ["@zk-email/sdk@3.0.0-nightly.34", "", { "dependencies": { "@azure/msal-browser": "^4.5.1", "@mach-34/noir-bignum-paramgen": "^1.1.2", "@peculiar/webcrypto": "^1.5.0", "@zk-email/relayer-utils": "0.4.66-18", "@zk-email/snarkjs": "^0.0.1", "ethers": "^6.13.4", "jszip": "^3.10.1", "poseidon-lite": "^0.3.0", "rsa-key": "^0.0.6", "snarkjs": "^0.7.5", "viem": "^2.21.53", "zod": "^3.23.8" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-RZuOm6kX8V2oXedRYYHxh8PUewNkhaC/F+5Sc7+BBP39dWAI/RHURTt4j9/kb/LoN/dDjyuG3KIFuo8ELr7DGg=="],
 
     "@zk-email/snarkjs": ["@zk-email/snarkjs@0.0.1", "", { "dependencies": { "@iden3/binfileutils": "0.0.12", "bfj": "^7.0.2", "blake2b-wasm": "^2.4.0", "circom_runtime": "0.1.28", "ejs": "^3.1.6", "fastfile": "0.0.20", "ffjavascript": "0.3.1", "js-sha3": "^0.8.0", "logplease": "^1.2.15", "r1csfile": "0.0.48" }, "bin": { "snarkjs": "build/cli.cjs" } }, "sha512-QJ2GfP4C5AW7gAshxHeToLwLdRy1hMiTMaL9AqJiW9hQ2zDD5gMFdav79q7Jwm3h42kzU3A+Na9zqpDr3Iue2w=="],
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@radix-ui/react-switch": "^1.1.1",
     "@radix-ui/react-tooltip": "^1.1.6",
     "@react-oauth/google": "^0.12.1",
-    "@zk-email/sdk": "3.0.0-nightly.30",
+    "@zk-email/sdk": "3.0.0-nightly.34",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "crypto": "^1.0.1",


### PR DESCRIPTION
## Summary
- Bumps @zk-email/sdk from 3.0.0-nightly.30 to 3.0.0-nightly.34
- Picks up zkemail/zk-email-sdk-js#103 (gates leftover debug console.log statements behind the SDK's logger instead of always firing)

## Test plan
- [x] typecheck passes