### PR TITLE
fix: force light theme to prevent white-on-light text on first visit

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -61,7 +61,13 @@ export default function RootLayout({
     <html lang="" suppressHydrationWarning>
       <body className={`${fustat.className} flex min-h-screen flex-col bg-[#F5F3EF] antialiased`}>
         <Suspense>
-          <ThemeProvider attribute="class">
+          {/* REASON: The app is a light-only design — the body bg is hardcoded to #F5F3EF
+              and all text colors assume a light background. next-themes defaults to
+              defaultTheme="system"/enableSystem, so dark-mode-OS visitors got the `dark`
+              class on <html>, flipping --foreground to near-white text on the light bg
+              (invisible main page text on first visit). There is no theme toggle in the UI,
+              so we force light. Removing forcedTheme reintroduces the white-on-light bug. */}
+          <ThemeProvider attribute="class" forcedTheme="light" enableSystem={false}>
             <CSPostHogProvider>
               <GoogleOAuthProvider clientId={process.env.GOOGLE_CLIENT_ID || ''}>
                 <GoogleAuthProvider>


### PR DESCRIPTION
## Summary
- Cherry-picks 0165e89 from main onto staging
- The app is a light-only design (hardcoded body bg, light text colors), but next-themes defaulted to system theme, so dark-mode-OS visitors got the `dark` class applied, flipping foreground to near-white text on the light background and making main page text invisible on first load
- Forces `forcedTheme="light"` on the ThemeProvider since there's no theme toggle in the UI

## Test plan
- [x] Cherry-picked cleanly, no conflicts